### PR TITLE
Add oauth2 workflow option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on Pmant's [node-botvac](https://github.com/Pmant/node-botvac), thanks to 
 ```npm install node-kobold```
 
 <a name="example"></a>
-## Usage Example
+## Usage Example (old auth using password)
 ```Javascript
 var kobold = require('node-kobold');
 
@@ -34,9 +34,33 @@ client.authorize('email', 'password', false, function (error) {
 });
 ```
 
+## Usage OAuth2 (for i.e. MyKobold app)
+```Javascript
+var kobold = require('node-kobold');
+
+var client = new kobold.Client();
+//authorize
+client.setToken(token);
+
+//get your robots
+client.getRobots(function (error, robots) {
+    if (error) {
+        console.log(error);
+        return;
+    }
+    if (robots.length) {
+        //do something        
+        robots[0].getState(function (error, result) {
+            console.log(result);
+        });
+    }
+});
+```
+
 <a name="client"></a>
 ## Client API
   * <a href="#authorize"><code>client.<b>authorize()</b></code></a>
+  * <a href="#setToken"><code>client.<b>setToken()</b></code></a>
   * <a href="#getRobots"><code>client.<b>getRobots()</b></code></a>
  
 -------------------------------------------------------
@@ -50,6 +74,14 @@ Login at the Vorwerk api.
 * `force` - force login if already authorized
 * `callback` - `function(error)`
   * `error` null if no error occurred
+
+-------------------------------------------------------
+<a name="setToken"></a>
+### client.setToken(token)
+
+Set a token that you already gathered via the oauth workflow
+
+* `token` - the OAuth token you acquired
 
 -------------------------------------------------------
 <a name="getRobots"></a>
@@ -318,3 +350,6 @@ Send robot to base.
 ### 0.1.3
 * (nicoh88) NoGo Lines and options sync
 * (nicoh88) Syncing cleaning options from last runupdate for npmjs
+
+### 0.2.0
+* (carlambroselli) Add oauth2 option

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ curl -X "POST" "https://mykobold.eu.auth0.com/passwordless/start" \
 ```
 ==== wait for the email to be received ====
 
-```
+```bash
 # this will generate a token using the numbers you received via email
 # replace the value of otp 123456 with the value you received from the email
 curl -X "POST" "https://mykobold.eu.auth0.com/oauth/token" \

--- a/README.md
+++ b/README.md
@@ -57,6 +57,46 @@ client.getRobots(function (error, robots) {
 });
 ```
 
+## Getting a token
+
+You can get a token using the following two curl commands:
+
+```bash
+# This will trigger the email sending
+curl -X "POST" "https://mykobold.eu.auth0.com/passwordless/start" \
+     -H 'Content-Type: application/json' \
+     -d $'{
+  "send": "code",
+  "email": "ENTER_YOUR_EMAIL_HERE",
+  "client_id": "KY4YbVAvtgB7lp8vIbWQ7zLk3hssZlhR",
+  "connection": "email"
+}'
+```
+==== wait for the email to be received ====
+
+```
+# this will generate a token using the numbers you received via email
+# replace the value of otp 123456 with the value you received from the email
+curl -X "POST" "https://mykobold.eu.auth0.com/oauth/token" \
+     -H 'Content-Type: application/json' \
+     -d $'{
+  "prompt": "login",
+  "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
+  "scope": "openid email profile read:current_user",
+  "locale": "en",
+  "otp": "123456",
+  "source": "vorwerk_auth0",
+  "platform": "ios",
+  "audience": "https://mykobold.eu.auth0.com/userinfo",
+  "username": "ENTER_YOUR_EMAIL_HERE",
+  "client_id": "KY4YbVAvtgB7lp8vIbWQ7zLk3hssZlhR",
+  "realm": "email",
+  "country_code": "DE"
+}'
+```
+
+From the output, you want to copy the `id_token` value.
+
 <a name="client"></a>
 ## Client API
   * <a href="#authorize"><code>client.<b>authorize()</b></code></a>

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,10 +3,15 @@ var robot = require(__dirname + '/robot');
 var crypto = require('crypto');
 
 function Client(t) {
-    this._baseUrl = 'https://vorwerk-beehive-production.herokuapp.com';
-    // this._baseUrl = 'https://beehive.neatocloud.com';
+    this._baseUrl = 'https://beehive.ksecosys.com';
     this._token = t;
+    this._prefix = "Token token="
 }
+
+Client.prototype.setToken = function (token) {
+    this._token = token;
+    this._prefix = "Auth0Bearer "
+};
 
 Client.prototype.authorize = function (email, password, force, callback) {
     if (!this._token || force) {
@@ -34,7 +39,7 @@ Client.prototype.authorize = function (email, password, force, callback) {
 
 Client.prototype.getRobots = function (callback) {
     if (this._token) {
-        api.request(this._baseUrl + '/dashboard', null, 'GET', {Authorization: 'Token token=' + this._token}, null, (function (error, body) {
+        api.request(this._baseUrl + '/dashboard', null, 'GET', {Authorization: this._prefix + this._token}, null, (function (error, body) {
             if (!error && body && body.robots) {
                 var robots = [];
                 for (var i = 0; i < body.robots.length; i++) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-kobold",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Vorwerk Kobold API for VR200 and VR300",
   "author": "nicoh88",
   "license": "MIT",


### PR DESCRIPTION
This PR adds the new oauth2 workflow to be used with the MyKobold app.

You can get a token using the following two curl commands:

```bash
# This will trigger the email sending
curl -X "POST" "https://mykobold.eu.auth0.com/passwordless/start" \
     -H 'Content-Type: application/json' \
     -d $'{
  "send": "code",
  "email": "ENTER_YOUR_EMAIL_HERE",
  "client_id": "KY4YbVAvtgB7lp8vIbWQ7zLk3hssZlhR",
  "connection": "email"
}'
```
==== wait for the email to be received ====

```
# this will generate a token using the numbers you received via email
# replace the value of otp 123456 with the value you received from the email
curl -X "POST" "https://mykobold.eu.auth0.com/oauth/token" \
     -H 'Content-Type: application/json' \
     -d $'{
  "prompt": "login",
  "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
  "scope": "openid email profile read:current_user",
  "locale": "en",
  "otp": "123456",
  "source": "vorwerk_auth0",
  "platform": "ios",
  "audience": "https://mykobold.eu.auth0.com/userinfo",
  "username": "ENTER_YOUR_EMAIL_HERE",
  "client_id": "KY4YbVAvtgB7lp8vIbWQ7zLk3hssZlhR",
  "realm": "email",
  "country_code": "DE"
}'
```

From the output, you want to copy the `id_token` value.